### PR TITLE
Add progress bars during preflight and page setup

### DIFF
--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -562,7 +562,7 @@ def process_pdf_to_csv(cfg, vendor_rules, extraction_rules, return_rows=False):
     t5 = time.time()
     print("    - Rotating Pages...")
     page_args = []
-    for idx, pil_img in enumerate(all_images):
+    for idx, pil_img in enumerate(tqdm(all_images, desc="Preparing pages", unit="page")):
         page_num = idx + 1
         if page_num in skip_pages:
             logging.info(f"Skipping page {page_num} (preflight)")

--- a/preflight.py
+++ b/preflight.py
@@ -7,6 +7,7 @@ import pytesseract
 from PIL import Image
 from PyPDF2 import PdfReader, PdfWriter
 from pdf2image import convert_from_path, pdfinfo_from_path
+from tqdm import tqdm
 
 
 def count_total_pages(pdf_files, cfg):
@@ -62,7 +63,7 @@ def preflight_pages(pdf_path, cfg):
     """
     bad = []
     total = count_total_pages([pdf_path], cfg)
-    for p in range(1, total + 1):
+    for p in tqdm(range(1, total + 1), desc="Preflight", unit="page"):
         if not is_page_ocrable(pdf_path, p, cfg):
             bad.append((p, "preflight-OCR failed"))
     return bad


### PR DESCRIPTION
## Summary
- show a tqdm progress bar when checking preflight pages
- show a tqdm progress bar when preparing pages for OCR

## Testing
- `python -m py_compile doctr_ocr_to_csv.py preflight.py input_picker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c06cd2b3c8331800073ff6226e3f6