### PR TITLE
Allow Poppler path via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ manifest numbers and other key fields.
 ## Prerequisites
 - **Python** 3.8 or newer (3.10+ recommended)
 - **System tools**: [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) and [Poppler](http://blog.alivate.com.au/poppler-windows/) for PDF rendering
+  - On **Windows**, set the `POPPLER_PATH` environment variable to Poppler's `bin` directory (or add it to `PATH`).
+  - On **macOS** or **Linux**, install Poppler via your package manager (`brew install poppler` or `apt-get install poppler-utils`). If the tools are not in your `PATH`, set `POPPLER_PATH` to the install location.
 - Install the required Python packages:
   ```bash
   pip install -r requirements.txt

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,9 @@ summary_report_dir: ./output/logs  # directory only, not the full filename
 
 vendor_keywords_csv: ./ocr_keywords.csv
 extraction_rules_yaml: ./extraction_rules.yaml
-poppler_path: C:/Poppler/poppler-24.08.0/Library/bin      # Poppler path for Windows/PDF2Image
+# Poppler path for PDF rendering. Leave blank to use the POPPLER_PATH
+# environment variable or system PATH.
+poppler_path: ""
 
 correct_orientation: true                 # Set false if docs are always upright
 parallel: true                            # USE parallel processing!

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,9 +11,9 @@ CSV reports.
 ## Prerequisites
 
 - **Python**: 3.8+ (recommended 3.10+)
-- **System Tools
-  **: [Tesseract OCR](https://github.com/tesseract-ocr/tesseract), [Poppler](http://blog.alivate.com.au/poppler-windows/) (
-  Windows: add Poppler's `bin` to your PATH)
+- **System Tools**: [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) and [Poppler](http://blog.alivate.com.au/poppler-windows/)
+  - On **Windows**, set the `POPPLER_PATH` environment variable to Poppler's `bin` directory (or add it to `PATH`).
+  - On **macOS** or **Linux**, install Poppler with your package manager (`brew install poppler` or `apt-get install poppler-utils`). If the tools are not in your `PATH`, set `POPPLER_PATH` to the install location.
 - **Python Packages**:
 
 ---
@@ -82,3 +82,10 @@ parallel: true
 num_workers: 4
 debug: false
 profile: false
+
+### Poppler Path
+
+`poppler_path` in `config.yaml` may be left blank. When blank, the script will
+look for the environment variable `POPPLER_PATH`. Set this variable to the
+directory containing Poppler's executables if they are not already in your
+`PATH`.

--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -71,7 +71,10 @@ def parse_roi(roi_cfg):
 
 def load_config(path="config.yaml"):
     with open(path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        cfg = yaml.safe_load(f)
+    if not cfg.get("poppler_path"):
+        cfg["poppler_path"] = os.environ.get("POPPLER_PATH")
+    return cfg
 
 
 def count_total_pages(pdf_files, cfg):


### PR DESCRIPTION
## Summary
- make `poppler_path` optional in config
- load Poppler path from `POPPLER_PATH` environment variable
- document Poppler setup on different platforms

## Testing
- `python -m py_compile doctr_ocr_to_csv.py input_picker.py preflight.py t2.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc13228588331972bf6d7acb3bdd8