### PR TITLE
Add duplicate and no-OCR page tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ manifest numbers and other key fields.
 
 The pipeline converts each page to images, runs Doctr OCR, applies regex/ROI
 rules to extract fields and writes combined and deduplicated CSV reports under
-`output/`.
+`output/`. It also creates exception CSVs:
+`ticket_number_exceptions.csv` for pages with no ticket number and
+`duplicate_ticket_exceptions.csv` for duplicate tickets and pages that produced
+no OCR text.
 
 ## Documentation
 - [User Guide](docs/USER_GUIDE.md) – step-by-step instructions and configuration examples

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -82,3 +82,10 @@ parallel: true
 num_workers: 4
 debug: false
 profile: false
+
+### Output Files
+
+- `combined_results.csv` – raw OCR results for every page
+- `ticket_numbers.csv` – unique tickets
+- `ticket_number_exceptions.csv` – pages with no ticket number
+- `duplicate_ticket_exceptions.csv` – duplicate tickets and pages with no OCR text


### PR DESCRIPTION
## Summary
- track pages with no OCR text
- record duplicate tickets across pages
- output duplicate and no-OCR info to a new CSV
- include new stats in summary
- document new CSVs

## Testing
- `python -m py_compile doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_685de1a930e48331b489d488550edbd2