### PR TITLE
Add configurable orientation check

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ vendor_keywords_csv: ./ocr_keywords.csv
 extraction_rules_yaml: ./extraction_rules.yaml
 poppler_path: C:/Poppler/poppler-24.08.0/Library/bin      # Poppler path for Windows/PDF2Image
 
-correct_orientation: true                 # Set false if docs are always upright
+orientation_check: tesseract            # tesseract, doctr, or none
 parallel: true                            # USE parallel processing!
 num_workers: 16                           # Start with 8, can go higher if you want
 identifier: ""                            # Optional: set if you want

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -76,9 +76,15 @@ output_csv: ./output/ocr/all_results.csv
 ticket_numbers_csv: ./output/ocr/ticket_numbers.csv
 output_images_dir: ./output/images/
 draw_roi: true
+orientation_check: tesseract  # tesseract, doctr, or none
 save_corrected_pdf: true
 corrected_pdf_path: ./output/ocr/corrected.pdf
 parallel: true
 num_workers: 4
 debug: false
 profile: false
+
+`orientation_check` determines how page rotation is handled:
+- `tesseract` (default): use Tesseract's OSD to correct orientation
+- `doctr`: use Doctr's angle prediction model
+- `none`: skip orientation checks

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -5,6 +5,7 @@ output_csv: ./output/ocr/all_results.csv
 ticket_numbers_csv: ./output/ocr/ticket_numbers.csv
 output_images_dir: ./output/images/
 draw_roi: true
+orientation_check: tesseract  # tesseract, doctr, or none
 save_corrected_pdf: true
 corrected_pdf_path: ./output/ocr/corrected.pdf
 parallel: true

--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -173,22 +173,36 @@ def extract_images_generator(filepath, poppler_path=None):
 
 
 # --- Orientation Correction ---
-def correct_image_orientation(pil_img, page_num=None):
+def correct_image_orientation(pil_img, page_num=None, method="tesseract"):
+    """Rotate a PIL image based on the chosen orientation method."""
+    if method == "none":
+        return pil_img
+
     try:
-        osd = pytesseract.image_to_osd(pil_img)
-        rotation_match = re.search(r"Rotate: (\d+)", osd)
-        if rotation_match:
-            rotation = int(rotation_match.group(1))
-            logging.info(f"Page {page_num}: OSD rotation = {rotation} degrees")
-            if rotation == 90:
-                return pil_img.rotate(-90, expand=True)
-            elif rotation == 180:
-                return pil_img.rotate(180, expand=True)
-            elif rotation == 270:
-                return pil_img.rotate(-270, expand=True)
+        if method == "doctr":
+            if correct_image_orientation.angle_model is None:
+                from doctr.models import angle_predictor
+
+                correct_image_orientation.angle_model = angle_predictor(
+                    pretrained=True
+                )
+            angle = correct_image_orientation.angle_model([pil_img])[0]
+            rotation = int(round(angle / 90.0)) * 90 % 360
+        else:  # tesseract
+            osd = pytesseract.image_to_osd(pil_img)
+            rotation_match = re.search(r"Rotate: (\d+)", osd)
+            rotation = int(rotation_match.group(1)) if rotation_match else 0
+
+        logging.info(f"Page {page_num}: rotation = {rotation} degrees")
+        if rotation in {90, 180, 270}:
+            return pil_img.rotate(-rotation, expand=True)
     except Exception as e:
         logging.warning(f"Orientation error (page {page_num}): {e}")
+
     return pil_img
+
+
+correct_image_orientation.angle_model = None
 
 
 # --- Ticket Extraction ---
@@ -382,8 +396,9 @@ def process_page(args):
     t0 = time.time()
 
     # Orientation
-    if cfg.get("correct_orientation", True):
-        pil_img = correct_image_orientation(pil_img, page_num=page_num)
+    orientation_method = cfg.get("orientation_check", "tesseract")
+    if orientation_method != "none":
+        pil_img = correct_image_orientation(pil_img, page_num=page_num, method=orientation_method)
         page_image_hash = get_image_hash(pil_img)
     timings["orientation"] = time.time() - t0 if cfg.get("profile", False) else None
 
@@ -567,8 +582,9 @@ def process_pdf_to_csv(cfg, vendor_rules, extraction_rules, return_rows=False):
         if page_num in skip_pages:
             logging.info(f"Skipping page {page_num} (preflight)")
             continue
-        if cfg.get("correct_orientation", True):
-            pil_img = correct_image_orientation(pil_img, page_num)
+        orientation_method = cfg.get("orientation_check", "tesseract")
+        if orientation_method != "none":
+            pil_img = correct_image_orientation(pil_img, page_num, method=orientation_method)
         if corrected_images is not None:
             corrected_images.append(pil_img.convert("RGB"))
         page_args.append((idx, pil_img, cfg, file_hash, identifier, extraction_rules))


### PR DESCRIPTION
## Summary
- support Doctr or disabled orientation corrections
- document `orientation_check` in sample configs and the user guide

## Testing
- `python doctr_ocr_to_csv.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_685df1fdc72c8331afa6022e424410cd