### PR TITLE
Fix image iteration variable

### DIFF
--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -558,7 +558,7 @@ def process_pdf_to_csv(cfg, vendor_rules, extraction_rules, return_rows=False):
 
     page_args = []
     for idx, pil_img in enumerate(
-        tqdm(all_images, desc="Preparing pages", unit="page")
+        tqdm(images_iter, desc="Preparing pages", unit="page")
     ):
         page_num = idx + 1
         if page_num in skip_pages:


### PR DESCRIPTION
## Summary
- correct variable name `all_images` to `images_iter` in `process_pdf_to_csv`

## Testing
- `python -m py_compile doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_685e111af1a88331b7f2f866597df571