### PR TITLE
Fix unmatched parenthesis error in OCR script

### DIFF
--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -557,12 +557,7 @@ def process_pdf_to_csv(cfg, vendor_rules, extraction_rules, return_rows=False):
     print("    - Rotating Pages...")
 
     page_args = []
-
     for idx, pil_img in enumerate(tqdm(all_images, desc="Preparing pages", unit="page")):
-
-        tqdm(images_iter, desc="Preparing pages", unit="page")
-    ):
-
         page_num = idx + 1
         if page_num in skip_pages:
             logging.info(f"Skipping page {page_num} (preflight)")


### PR DESCRIPTION
## Summary
- remove stray lines in page processing loop
- clean up iteration logic

## Testing
- `python -m py_compile doctr_ocr_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_685e1c9be83c83318292c7f77ae21f21