### PR TITLE
Clarify meaning of duplicate ticket pages in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ The pipeline converts each page to images, runs Doctr OCR, applies regex/ROI
 rules to extract fields and writes combined and deduplicated CSV reports under
 `output/`. It also creates exception CSVs:
 `ticket_number_exceptions.csv` for pages with no ticket number and
-`duplicate_ticket_exceptions.csv` for duplicate tickets and pages that produced
-no OCR text.
+`duplicate_ticket_exceptions.csv` for pages where the same vendor and ticket number combination occurs more than once and for pages that produced no OCR text.
 
 ## Documentation
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -63,7 +63,7 @@
 ### Output & Stats
 
 - Outputs all data as CSV, including ROI images if requested
-- Deduplicates tickets by (vendor, ticket_number)
+- Deduplicates tickets by vendor and ticket number to flag pages that reuse the same ticket across the dataset
 - Stats: total files, pages, valid/review/invalid manifests, missing tickets
 
 ---

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -94,5 +94,5 @@ profile: false
 - `combined_results.csv` – raw OCR results for every page
 - `ticket_numbers.csv` – unique tickets
 - `ticket_number_exceptions.csv` – pages with no ticket number
-- `duplicate_ticket_exceptions.csv` – duplicate tickets and pages with no OCR text
+- `duplicate_ticket_exceptions.csv` – pages where the same vendor and ticket number combination appears more than once ("duplicate ticket pages") and any pages that produced no OCR text
 


### PR DESCRIPTION
## Summary
- clarify that duplicate pages refer to repeated vendor/ticket combos
- document duplicate page logic in developer guide

## Testing
- `python -m py_compile doctr_ocr_to_csv.py input_picker.py preflight.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2116296883318cbc17674f55c1ab