### PR TITLE
Add ROI link column to ticket numbers report

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The pipeline converts each page to images, runs Doctr OCR, applies regex/ROI
 rules to extract fields and writes CSV reports under `output/`.
 `combined_ticket_numbers.csv` now contains one row for each processed page with
 a `duplicate_ticket` flag so missing or repeated numbers are easy to spot. It
+also includes a "ROI Image Link" column pointing to the highlighted ticket area
+whenever the `ticket_valid` status is not `valid`. It
 also creates exception CSVs:
 `ticket_number_exceptions.csv` for pages with no ticket number and
 `duplicate_ticket_exceptions.csv` for pages where the same vendor and ticket number combination occurs more than once and for pages that produced no OCR text.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -92,7 +92,8 @@ profile: false
 ### Output Files
 
 - `combined_results.csv` – raw OCR results for every page
-- `combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag
+- `combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag and
+  a **ROI Image Link** column when `ticket_valid` is not `valid`
 - `ticket_number_exceptions.csv` – pages with no ticket number
 - `duplicate_ticket_exceptions.csv` – pages where the same vendor and ticket number combination appears more than once ("duplicate ticket pages") and any pages that produced no OCR text
 

--- a/doctr_ocr_to_csv.py
+++ b/doctr_ocr_to_csv.py
@@ -839,6 +839,18 @@ def main():
         if dedupe_key not in unique_tickets and ticket_number:
             # Build deduped summary of tickets. Each key is (vendor_name, ticket_number).
             # Value is a tuple matching the ticket_numbers_csv header order.
+            roi_link = ""
+            if row[19] != "valid":
+                roi_path = build_roi_image_path(
+                    row[1],
+                    row[5],
+                    cfg.get("output_images_dir", "./output/images"),
+                    cfg["ticket_numbers_csv"],
+                    vendor_name,
+                    ticket_number,
+                )
+                roi_link = f'=HYPERLINK("{roi_path}","View ROI")'
+
             unique_tickets[dedupe_key] = (
                 row[5],  # page
                 vendor_name,
@@ -852,6 +864,7 @@ def main():
                 row[1],  # file_path
                 row[4],  # page_image_hash
                 row[3],  # file_hash
+                roi_link,
             )
         elif ticket_number:
             dup_key = (row[0], row[5], vendor_name, ticket_number)
@@ -1088,6 +1101,7 @@ def main():
                     "file_path",
                     "page_image_hash",
                     "file_hash",
+                    "ROI Image Link",
                 ]
             )
         for key in sorted_keys:
@@ -1095,6 +1109,17 @@ def main():
             ticket_num = rec["ticket_number"]
             ticket_status = rec["ticket_valid"] if ticket_num else "no ticket"
             dup_flag = "true" if key in duplicate_page_keys else "false"
+            roi_link = ""
+            if ticket_status != "valid":
+                roi_path = build_roi_image_path(
+                    rec["file_path"],
+                    rec["page"],
+                    cfg.get("output_images_dir", "./output/images"),
+                    ticket_csv_path,
+                    rec["vendor_name"],
+                    ticket_num,
+                )
+                roi_link = f'=HYPERLINK("{roi_path}","View ROI")'
             w.writerow(
                 [
                     rec["page"],
@@ -1110,6 +1135,7 @@ def main():
                     rec["file_path"],
                     rec["page_image_hash"],
                     rec["file_hash"],
+                    roi_link,
                 ]
             )
 


### PR DESCRIPTION
## Summary
- include ROI hyperlink for non-valid ticket pages in `combined_ticket_numbers.csv`
- document new column in README and User Guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2a19c7fc83318c332c3241eb50ac