### PR TITLE
Add manifest ROI images and exception reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The pipeline converts each page to images, runs Doctr OCR, applies regex/ROI
 rules to extract fields and writes CSV reports under `output/`.
 `combined_ticket_numbers.csv` now contains one row for each processed page with
 a `duplicate_ticket` flag so missing or repeated numbers are easy to spot. It
-also includes a "ROI Image Link" column pointing to the highlighted ticket area
-whenever the `ticket_valid` status is not `valid`. It
+also includes "ROI Image Link" and "Manifest ROI Link" columns pointing to the
+highlighted areas whenever the corresponding value is not `valid`. It
 also creates exception CSVs:
 `ticket_number_exceptions.csv` for pages with no ticket number and
-`duplicate_ticket_exceptions.csv` for pages where the same vendor and ticket number combination occurs more than once and for pages that produced no OCR text.
+`duplicate_ticket_exceptions.csv` for pages where the same vendor and ticket number combination occurs more than once and for pages that produced no OCR text, and `manifest_number_exceptions.csv` for pages with missing or invalid manifest numbers.
 
 ## Documentation
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ ticket_numbers_csv: ./output/ticket_number/combined_ticket_numbers.csv
 
 # Pages that had *no* ticket numbers
 ticket_number_exceptions_csv: ./output/logs/ticket_number/ticket_number_exceptions.csv
+manifest_number_exceptions_csv: ./output/logs/manifest_number/manifest_number_exceptions.csv
 
 # Summary stats
 summary_report_dir: ./output/logs/summary  # directory only, not the full filename

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -93,7 +93,8 @@ profile: false
 
 - `combined_results.csv` – raw OCR results for every page
 - `combined_ticket_numbers.csv` – one row per page with a `duplicate_ticket` flag and
-  a **ROI Image Link** column when `ticket_valid` is not `valid`
+  **ROI Image Link** and **Manifest ROI Link** columns when the respective values are not `valid`
 - `ticket_number_exceptions.csv` – pages with no ticket number
 - `duplicate_ticket_exceptions.csv` – pages where the same vendor and ticket number combination appears more than once ("duplicate ticket pages") and any pages that produced no OCR text
+- `manifest_number_exceptions.csv` – pages where the manifest number is missing or invalid
 

--- a/docs/sample_config.yaml
+++ b/docs/sample_config.yaml
@@ -3,6 +3,7 @@ input_dir: ./data/
 batch_mode: true
 output_csv: ./output/ocr/all_results.csv
 ticket_numbers_csv: ./output/ocr/combined_ticket_numbers.csv
+manifest_number_exceptions_csv: ./output/logs/manifest_number/manifest_number_exceptions.csv
 output_images_dir: ./output/images/
 draw_roi: true
 orientation_check: tesseract  # tesseract, doctr, or none


### PR DESCRIPTION
## Summary
- add `save_roi_image` helper and generalize ROI path builder
- highlight and save manifest ROI images
- link manifest ROI in combined ticket CSV
- record manifest number exceptions
- document new files and config options
- extend tests for ROI path builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4e2172e88331b04527cabf87fc1f